### PR TITLE
ProjectID error in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,7 +55,7 @@ brews:
   - name: price
     homepage: https://github.com/rxxcc/price-action
     tap:
-      owner: Inu John
+      owner: rxxcc
       name: homebrew-rxxcc
     commit_author:
       name: rxxcc


### PR DESCRIPTION
- Changed owner name brews tap owner name in `.goreleaser.yml`